### PR TITLE
Database error ref count fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+ext/esqlver.h
+ext/_informixdb.c
+*.swp
 
 # Installer logs
 pip-log.txt

--- a/ext/_informixdb.ec
+++ b/ext/_informixdb.ec
@@ -2,6 +2,7 @@
  *                Copyright (c) 1997 by IV DocEye AB
  *             Copyright (c) 1999 by Stephen J. Turner
  *               Copyright (c) 2006 by Carsten Haese
+ *                 Copyright (c) 2017 by NetworkIP
  *
  * By obtaining, using, and/or copying this software and/or its
  * associated documentation, you agree that you have read, understood,

--- a/ext/_informixdb.ec
+++ b/ext/_informixdb.ec
@@ -3296,7 +3296,6 @@ static PyObject* DatabaseError_init(PyObject* self, PyObject* args, PyObject* kw
     return NULL;
   }
 
-
   if (PyObject_SetAttrString(self, "diagnostics", diags)) {
     return NULL;
   }
@@ -3342,9 +3341,10 @@ static PyObject* DatabaseError_str(PyObject* self, PyObject* args)
 
   if (PyObject_IsTrue(sqlerrm)) {
     PyString_ConcatAndDel(&str, PyString_FromString("SQLERRM = "));
-    PyString_ConcatAndDel(&str, sqlerrm); //DECREF sqlerrm
+    PyString_Concat(&str, sqlerrm);
     PyString_ConcatAndDel(&str, PyString_FromString("\n"));
   }
+  Py_DECREF(sqlerrm);
 
   return str;
 }


### PR DESCRIPTION
There are two errors, one of which exposed the other.

1) In `a = Py_BuildValue("(NN)", sqlcode, action);`, the N's do not increase the reference count on the object. Because of this, the added `Py_DECREF`s for `sqlcode` and `action` and the `Py_DECREF` for `a` result in too many decrements for the first two and a potential segfault. The fix is to either remove the decrements at the bottom of `DatabaseError_str` *or* to change the `PyBuildValue` to use O's instead of N's. I went with the former option.

2) At this point, I noticed that the `Py_DECREF(sqlcode);` wasn't causing a segfault like `Py_DECREF(action)` was. This is because `DatabaseError_init` was failing to decrement the reference for `sqlcode`; `PyInt_FromLong` increments the reference counter automatically. Anyway, adding a `Py_DECREF` fixes the issue.

On the side, I extended the .gitignore a bit. Rest of the changes are just style decisions.